### PR TITLE
#164684792 fixed admin deleted email false response bug

### DIFF
--- a/server/controllers/message.js
+++ b/server/controllers/message.js
@@ -310,12 +310,11 @@ const messages = {
 
   deleteSpecificEmail(req, res) {
     const emailId = req.params.id;
-    const admin = req.userId;
-    const userAccess = "true";
     const user = req.userId;
-    const retrieveAdmin = database(sql.retrieveAdmin, [admin, userAccess]);
+    const userAccess = "true";
+    const retrieveAdmin = database(sql.retrieveAdmin, [user, userAccess]);
     retrieveAdmin.then((response) => {
-      if (response) {
+      if (response.length !== 0) {
         const specificEmail = database(sql.retrieveSpecificEmail, [emailId]);
         specificEmail.then((response) => {
           if (response.length === 0 || response.length === "undefined") {
@@ -356,8 +355,6 @@ const messages = {
           res.status(500).json({ error: "error occured", error });
         });
       }
-    }).catch((error) => {
-      res.status(500).json({ error: "error occured", error });
     });
   },
 };


### PR DESCRIPTION
#### What does this PR do?
It fixes the bug of a false response that a user gets when they delete an email. The response indicates that it is the admin who has deleted the email while it is the user.

#### Description of Task to be done?
The buggy code block will be removed.

#### How should this be manually tested?
1. Start the **Server** and **POSTMAN**.
2. **Browse** the following endpoint route: **localhost:3000/api/v2/messages/13** with **HTTP DELETE** method.
4. Check to see if the response does not indicate that the admin is the one who has deleted the email, because you are a standard user.